### PR TITLE
Declare uuid as dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,6 +22,7 @@ Depends:
 Imports:
     pkgdepends,
     jsonlite,
-    utils
+    utils,
+    uuid
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.2


### PR DESCRIPTION
Used in `cran_pkg_sbom()` to create serialNumber